### PR TITLE
feat: Add child add and type swap feature In Project Map  Editor

### DIFF
--- a/app/src/api/routes/project/project_map_edit.ts
+++ b/app/src/api/routes/project/project_map_edit.ts
@@ -36,27 +36,6 @@ const project_id_input = z.object({
   project_id: z.int()
 });
 
-const PROJECT_MAP_ORDER_LOCK_NAMESPACE = 41021;
-
-const db_path_schema = z
-  .string()
-  .regex(DB_PATH_RE, 'Path must be a colon-separated list of positive integers');
-
-const path_swap_edit_schema = z.object({
-  /** Ordered as `[from_path, to_path]`; server stages `to_path + "_temp"` to avoid clashes. */
-  swap_paths: z.tuple([db_path_schema, db_path_schema])
-});
-
-const update_project_map_input = project_id_input.extend({
-  map: recursive_list_schema
-});
-
-const save_project_map_order_input = project_id_input.extend({
-  root_path: z.array(z.int().positive()),
-  edits: z.array(path_swap_edit_schema),
-  map: recursive_list_schema
-});
-
 const invalidate_project_caches = async (
   cookie: string,
   project_id: number,
@@ -79,7 +58,11 @@ const invalidate_project_caches = async (
 };
 
 export const update_project_map_route = protectedAdminProcedure
-  .input(update_project_map_input)
+  .input(
+    project_id_input.extend({
+      map: recursive_list_schema
+    })
+  )
   .mutation(async ({ input, ctx: { cookie } }) => {
     await delay(400);
     const project = await db.transaction(async (tx) => {
@@ -118,8 +101,25 @@ export const update_project_map_route = protectedAdminProcedure
     return { success: true as const, map: project.map };
   });
 
+const PROJECT_MAP_ORDER_LOCK_NAMESPACE = 41021;
+
+const db_path_schema = z
+  .string()
+  .regex(DB_PATH_RE, 'Path must be a colon-separated list of positive integers');
+
 const save_project_map_order = protectedAdminProcedure
-  .input(save_project_map_order_input)
+  .input(
+    project_id_input.extend({
+      root_path: z.array(z.int().positive()),
+      edits: z.array(
+        z.object({
+          /** Ordered as `[from_path, to_path]`; server stages `to_path + "_temp"` to avoid clashes. */
+          swap_paths: z.tuple([db_path_schema, db_path_schema])
+        })
+      ),
+      map: recursive_list_schema
+    })
+  )
   .mutation(async ({ input: { project_id, root_path, edits, map }, ctx: { cookie } }) => {
     const parsedEdits = edits;
     if (parsedEdits.length > 0) {

--- a/app/src/api/routes/project/project_map_edit.ts
+++ b/app/src/api/routes/project/project_map_edit.ts
@@ -36,6 +36,8 @@ const project_id_input = z.object({
   project_id: z.int()
 });
 
+const PROJECT_MAP_ORDER_LOCK_NAMESPACE = 41021;
+
 const invalidate_project_caches = async (
   cookie: string,
   project_id: number,
@@ -100,8 +102,6 @@ export const update_project_map_route = protectedAdminProcedure
     await invalidate_project_caches(cookie, input.project_id, project.key);
     return { success: true as const, map: project.map };
   });
-
-const PROJECT_MAP_ORDER_LOCK_NAMESPACE = 41021;
 
 const db_path_schema = z
   .string()

--- a/app/src/components/pages/map_edit/ChangesPanel.svelte
+++ b/app/src/components/pages/map_edit/ChangesPanel.svelte
@@ -29,14 +29,18 @@
     rename: 'Rename',
     list_name_change: 'Label',
     expected_count_change: 'Count',
-    reorder: 'Reorder'
+    reorder: 'Reorder',
+    add_child: 'Add child',
+    type_change: 'Convert type'
   };
 
   const kind_styles: Record<MapChangeKind, string> = {
     rename: 'bg-sky-500/15 text-sky-700 dark:text-sky-300',
     list_name_change: 'bg-violet-500/15 text-violet-700 dark:text-violet-300',
     expected_count_change: 'bg-amber-500/15 text-amber-800 dark:text-amber-200',
-    reorder: 'bg-emerald-500/15 text-emerald-700 dark:text-emerald-300'
+    reorder: 'bg-emerald-500/15 text-emerald-700 dark:text-emerald-300',
+    add_child: 'bg-teal-500/15 text-teal-800 dark:text-teal-200',
+    type_change: 'bg-rose-500/15 text-rose-800 dark:text-rose-200'
   };
 
   const rows = $derived(active_diff_state.rows);

--- a/app/src/components/pages/map_edit/NodeEditor.svelte
+++ b/app/src/components/pages/map_edit/NodeEditor.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
-  import { PenLine, TriangleAlert } from '@lucide/svelte';
+  import { PenLine, TriangleAlert, Plus, ArrowLeftRight } from '@lucide/svelte';
   import { Input } from '$lib/components/ui/input';
   import { Label } from '$lib/components/ui/label';
   import { Switch } from '$lib/components/ui/switch';
+  import { Button } from '$lib/components/ui/button';
   import * as Card from '$lib/components/ui/card';
+  import * as Popover from '$lib/components/ui/popover';
   import { Separator } from '$lib/components/ui/separator';
   import type { MapNodeWithClientId } from './map_edit_lib';
   import {
@@ -22,7 +24,11 @@
     count_input_invalid = false,
     onNameDevChange,
     onListNameChange,
-    onListCountChange
+    onListCountChange,
+    onAddShlokaChild,
+    onAddListChild,
+    onConvertToList,
+    onConvertToShloka
   }: {
     editor_locked: boolean;
     order_edit_mode: boolean;
@@ -34,7 +40,28 @@
     onNameDevChange: (value: string) => void;
     onListNameChange: (value: string) => void;
     onListCountChange: (raw: string) => void;
+    onAddShlokaChild: () => void;
+    onAddListChild: () => void;
+    onConvertToList: () => void;
+    onConvertToShloka: () => void;
   } = $props();
+
+  let add_child_popover_open = $state(false);
+
+  const selected_childless = $derived((selectedNode?.list?.length ?? 0) === 0);
+  const show_add_child = $derived(
+    !order_edit_mode && selectedNode?.info.type === 'list' && !editor_locked
+  );
+  const show_convert_to_list = $derived(
+    !order_edit_mode && selectedNode?.info.type === 'shloka' && selected_childless && !editor_locked
+  );
+  const show_convert_to_shloka = $derived(
+    !order_edit_mode &&
+      !selected_is_root &&
+      selectedNode?.info.type === 'list' &&
+      selected_childless &&
+      !editor_locked
+  );
 
   let typing_ctx = $derived(createTypingContext('Devanagari'));
 
@@ -147,6 +174,72 @@
           </p>
         {/if}
       </div>
+
+      {#if show_add_child || show_convert_to_list || show_convert_to_shloka}
+        <Separator />
+        <div class="flex flex-wrap gap-2">
+          {#if show_add_child}
+            <Popover.Root bind:open={add_child_popover_open}>
+              <Popover.Trigger class="p-0 outline-none">
+                <Button type="button" variant="outline" size="sm" class="gap-1.5">
+                  <Plus class="size-3.5" />
+                  Add child
+                </Button>
+              </Popover.Trigger>
+              <Popover.Content align="start" class="w-44 p-1">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  class="w-full justify-start"
+                  onclick={() => {
+                    add_child_popover_open = false;
+                    onAddShlokaChild();
+                  }}
+                >
+                  Add Shloka
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  class="w-full justify-start"
+                  onclick={() => {
+                    add_child_popover_open = false;
+                    onAddListChild();
+                  }}
+                >
+                  Add List
+                </Button>
+              </Popover.Content>
+            </Popover.Root>
+          {/if}
+          {#if show_convert_to_list}
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              class="gap-1.5"
+              onclick={onConvertToList}
+            >
+              <ArrowLeftRight class="size-3.5" />
+              Convert to List
+            </Button>
+          {/if}
+          {#if show_convert_to_shloka}
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              class="gap-1.5"
+              onclick={onConvertToShloka}
+            >
+              <ArrowLeftRight class="size-3.5" />
+              Convert to Shloka
+            </Button>
+          {/if}
+        </div>
+      {/if}
 
       {#if selectedNode.info.type === 'list'}
         <Separator />

--- a/app/src/components/pages/map_edit/ProjectMapEditor.svelte
+++ b/app/src/components/pages/map_edit/ProjectMapEditor.svelte
@@ -122,7 +122,7 @@
   const metadata_field_dirty = $derived.by(() => {
     if (!workingMap || order_edit_mode) return false;
     return compute_map_edit_diff(workingMap, baselineSnapshots, {
-      kinds: ['rename', 'list_name_change', 'expected_count_change']
+      kinds: ['rename', 'list_name_change', 'expected_count_change', 'add_child', 'type_change']
     }).dirty;
   });
 
@@ -465,7 +465,7 @@
   function enter_order_edit_mode() {
     if (!workingMap || order_edit_mode || save_in_flight) return;
     if (metadata_field_dirty) {
-      toast.error('Save or discard field edits before changing order');
+      toast.error('Save or discard map edits before changing order');
       return;
     }
     order_entry_map = clone_working_map(workingMap);

--- a/app/src/components/pages/map_edit/ProjectMapEditor.svelte
+++ b/app/src/components/pages/map_edit/ProjectMapEditor.svelte
@@ -265,7 +265,8 @@
   }
 
   function set_base_path(path: MapPath) {
-    if (!workingMap || save_in_flight || !is_path_valid(workingMap, path) || order_edit_mode) return;
+    if (!workingMap || save_in_flight || !is_path_valid(workingMap, path) || order_edit_mode)
+      return;
     basePath = path;
     if (!is_path_valid(workingMap, selectedNodePath)) {
       selectedNodePath = path.length === 0 ? [] : path;
@@ -477,12 +478,7 @@
   }
 
   async function confirm_save_order() {
-    if (
-      !workingMap ||
-      save_in_flight ||
-      !order_root_selected ||
-      pending_swaps.length === 0
-    ) {
+    if (!workingMap || save_in_flight || !order_root_selected || pending_swaps.length === 0) {
       return;
     }
     saving_order = true;
@@ -683,14 +679,15 @@
       {:else if order_root_awaiting}
         <div class="rounded-md bg-amber-500/8 px-3 py-1.5 dark:bg-amber-400/8">
           <p class="text-xs text-amber-800 dark:text-amber-300">
-            Click a list node in the tree that has at least two children to choose what you want to reorder.
+            Click a list node in the tree that has at least two children to choose what you want to
+            reorder.
           </p>
         </div>
       {:else}
         <div class="rounded-md bg-amber-500/8 px-3 py-1.5 dark:bg-amber-400/8">
           <p class="text-xs text-amber-800 dark:text-amber-300">
-            You can reorder direct children in <span class="font-medium text-amber-950 dark:text-amber-100"
-              >{order_root_resolved}</span
+            You can reorder direct children in <span
+              class="font-medium text-amber-950 dark:text-amber-100">{order_root_resolved}</span
             >. Drag rows with the grip handle only.
           </p>
         </div>

--- a/app/src/components/pages/map_edit/ProjectMapEditor.svelte
+++ b/app/src/components/pages/map_edit/ProjectMapEditor.svelte
@@ -39,6 +39,9 @@
     clone_baseline_snapshots,
     clone_working_map,
     clone_recursive_list,
+    create_map_edit_child,
+    apply_map_edit_list_defaults,
+    apply_map_edit_shloka_defaults,
     MAP_EDIT_CLIENT_ID,
     format_path_resolved_label,
     paths_equal,
@@ -366,6 +369,46 @@
     mark_local_change();
     count_input_invalid = false;
     selectedNode.info = { ...selectedNode.info, list_count_expected: parsed };
+    bump_working();
+  }
+
+  function append_child(kind: 'shloka' | 'list') {
+    if (!selectedNode || selectedNode.info.type !== 'list' || order_edit_mode || save_in_flight) {
+      return;
+    }
+    mark_local_change();
+    selectedNode.list = [...(selectedNode.list ?? []), create_map_edit_child(kind)];
+    bump_working();
+  }
+
+  function convert_selected_to_list() {
+    if (
+      !selectedNode ||
+      selectedNode.info.type !== 'shloka' ||
+      (selectedNode.list ?? []).length > 0 ||
+      order_edit_mode ||
+      save_in_flight
+    ) {
+      return;
+    }
+    mark_local_change();
+    apply_map_edit_list_defaults(selectedNode, { preserve_name_dev: selected_is_root });
+    bump_working();
+  }
+
+  function convert_selected_to_shloka() {
+    if (
+      !selectedNode ||
+      selectedNode.info.type !== 'list' ||
+      (selectedNode.list ?? []).length > 0 ||
+      selected_is_root ||
+      order_edit_mode ||
+      save_in_flight
+    ) {
+      return;
+    }
+    mark_local_change();
+    apply_map_edit_shloka_defaults(selectedNode, { preserve_name_dev: selected_is_root });
     bump_working();
   }
 
@@ -722,6 +765,10 @@
       onNameDevChange={update_name_dev}
       onListNameChange={update_list_name}
       onListCountChange={update_list_count_expected}
+      onAddShlokaChild={() => append_child('shloka')}
+      onAddListChild={() => append_child('list')}
+      onConvertToList={convert_selected_to_list}
+      onConvertToShloka={convert_selected_to_shloka}
     />
   </div>
 

--- a/app/src/components/pages/map_edit/TreeEditPanel.svelte
+++ b/app/src/components/pages/map_edit/TreeEditPanel.svelte
@@ -77,9 +77,9 @@
             shouldToggleOnNodeClick={false}
             dragDropMode={order_root_selected && !editor_locked ? 'self' : 'none'}
             allowedDropPositionsMember="allowedDropPositions"
-            getAllowedDropPositionsCallback={
-              order_root_selected && !editor_locked ? getAllowedDropPositions : undefined
-            }
+            getAllowedDropPositionsCallback={order_root_selected && !editor_locked
+              ? getAllowedDropPositions
+              : undefined}
             beforeDropCallback={beforeDrop}
             {onNodeClicked}
           >

--- a/app/src/components/pages/map_edit/map_edit_lib.test.ts
+++ b/app/src/components/pages/map_edit/map_edit_lib.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+import {
+  apply_map_edit_list_defaults,
+  clone_map_with_client_ids,
+  compute_map_edit_diff,
+  create_map_edit_child,
+  get_node_at_map_path,
+  type BaselineNodeSnapshot,
+  type MapNodeWithClientId
+} from './map_edit_lib';
+import type { recursive_list_type } from '~/state/data_types';
+
+const base_map = (): recursive_list_type => ({
+  name_dev: 'Project',
+  info: { type: 'list', list_name: 'Kanda', list_count_expected: null },
+  list: [
+    {
+      name_dev: 'List A',
+      info: { type: 'list', list_name: 'Sarga', list_count_expected: null },
+      list: [
+        {
+          name_dev: 'Shloka 1',
+          info: { type: 'shloka', shloka_count: 1, total: 1, shloka_count_expected: null },
+          list: []
+        }
+      ]
+    },
+    {
+      name_dev: 'Shloka leaf',
+      info: { type: 'shloka', shloka_count: 0, total: 0, shloka_count_expected: null },
+      list: []
+    }
+  ]
+});
+
+function setup_working() {
+  const snapshots = new Map<string, BaselineNodeSnapshot>();
+  const working = clone_map_with_client_ids(base_map(), null, 0, snapshots);
+  return { working, snapshots };
+}
+
+describe('map_edit_lib normal-mode structure edits', () => {
+  it('creates shloka and list children with expected defaults', () => {
+    const shloka = create_map_edit_child('shloka');
+    expect(shloka.name_dev).toBe('नवश्लोकानि');
+    expect(shloka.info).toEqual({
+      type: 'shloka',
+      shloka_count: 0,
+      total: 0,
+      shloka_count_expected: null
+    });
+    expect(shloka.list).toEqual([]);
+
+    const list = create_map_edit_child('list');
+    expect(list.name_dev).toBe('नवसूची');
+    expect(list.info).toEqual({
+      type: 'list',
+      list_name: 'Level Name',
+      list_count_expected: null
+    });
+  });
+
+  it('detects appended children as add_child changes', () => {
+    const { working, snapshots } = setup_working();
+    const listNode = get_node_at_map_path(working, [1])!;
+    listNode.list = [...(listNode.list ?? []), create_map_edit_child('shloka')];
+
+    const diff = compute_map_edit_diff(working, snapshots);
+    expect(diff.dirty).toBe(true);
+    expect(diff.rows.some((r) => r.kind === 'add_child')).toBe(true);
+    expect(diff.rows.some((r) => r.summary === 'Added shloka child at position 2')).toBe(true);
+  });
+
+  it('preserves name_dev when applying list defaults on the map root', () => {
+    const { working } = setup_working();
+    const rootName = working.name_dev;
+    apply_map_edit_list_defaults(working, { preserve_name_dev: true });
+    expect(working.name_dev).toBe(rootName);
+    expect(working.info.type).toBe('list');
+    expect(working.info.type === 'list' && working.info.list_name).toBe('Level Name');
+  });
+
+  it('does not emit type_change for unsaved added nodes', () => {
+    const { working, snapshots } = setup_working();
+    const listNode = get_node_at_map_path(working, [1])!;
+    const added = create_map_edit_child('shloka');
+    listNode.list = [...(listNode.list ?? []), added];
+    apply_map_edit_list_defaults(added);
+
+    const diff = compute_map_edit_diff(working, snapshots);
+    expect(diff.rows.filter((r) => r.kind === 'type_change')).toHaveLength(0);
+    expect(diff.rows.some((r) => r.kind === 'add_child' && r.summary.includes('list'))).toBe(true);
+  });
+
+  it('detects childless shloka to list conversion', () => {
+    const { working, snapshots } = setup_working();
+    const node = get_node_at_map_path(working, [2]) as MapNodeWithClientId;
+    node.info = { type: 'list', list_name: 'Section', list_count_expected: null };
+    node.list = [];
+
+    const diff = compute_map_edit_diff(working, snapshots);
+    expect(diff.rows.some((r) => r.kind === 'type_change')).toBe(true);
+    expect(diff.rows.some((r) => r.summary === 'Converted Shloka → List')).toBe(true);
+  });
+
+  it('detects childless list to shloka conversion', () => {
+    const { working, snapshots } = setup_working();
+    const node = get_node_at_map_path(working, [1]) as MapNodeWithClientId;
+    node.info = { type: 'shloka', shloka_count: 0, total: 0, shloka_count_expected: null };
+    node.list = [];
+
+    const diff = compute_map_edit_diff(working, snapshots);
+    expect(diff.rows.some((r) => r.summary === 'Converted List → Shloka')).toBe(true);
+  });
+});

--- a/app/src/components/pages/map_edit/map_edit_lib.test.ts
+++ b/app/src/components/pages/map_edit/map_edit_lib.test.ts
@@ -58,6 +58,7 @@ describe('map_edit_lib normal-mode structure edits', () => {
       list_name: 'Level Name',
       list_count_expected: null
     });
+    expect(list.list).toEqual([]);
   });
 
   it('detects appended children as add_child changes', () => {

--- a/app/src/components/pages/map_edit/map_edit_lib.ts
+++ b/app/src/components/pages/map_edit/map_edit_lib.ts
@@ -9,7 +9,13 @@ export type MapNodeWithClientId = recursive_list_type & {
 
 export type MapPath = number[];
 
-export type MapChangeKind = 'rename' | 'list_name_change' | 'expected_count_change' | 'reorder';
+export type MapChangeKind =
+  | 'rename'
+  | 'list_name_change'
+  | 'expected_count_change'
+  | 'reorder'
+  | 'add_child'
+  | 'type_change';
 
 export type MapChangeRow = {
   kind: MapChangeKind;
@@ -42,6 +48,63 @@ export type BaselineNodeSnapshot = {
 };
 
 const new_client_id = () => crypto.randomUUID();
+
+/** List-type label (`info.list_name`); always this for new or converted list nodes. */
+export const MAP_EDIT_DEFAULT_LIST_LEVEL_NAME = 'Level Name';
+export const MAP_EDIT_DEFAULT_SHLOKA_NAME_DEV = 'नवश्लोकानि';
+export const MAP_EDIT_DEFAULT_LIST_NAME_DEV = 'नवसूची';
+
+export const is_unsaved_added_map_node = (
+  clientId: string | undefined,
+  snapshots: Map<string, BaselineNodeSnapshot>
+): boolean => Boolean(clientId && !snapshots.has(clientId));
+
+export type MapEditTypeDefaultsOptions = {
+  /** Keep `name_dev` (map root = project `name_dev` per `recursive_list_schema`). */
+  preserve_name_dev?: boolean;
+};
+
+export const apply_map_edit_shloka_defaults = (
+  node: MapNodeWithClientId,
+  options?: MapEditTypeDefaultsOptions
+): void => {
+  if (!options?.preserve_name_dev) {
+    node.name_dev = MAP_EDIT_DEFAULT_SHLOKA_NAME_DEV;
+  }
+  node.info = { type: 'shloka', shloka_count: 0, total: 0, shloka_count_expected: null };
+  node.list = [];
+};
+
+export const apply_map_edit_list_defaults = (
+  node: MapNodeWithClientId,
+  options?: MapEditTypeDefaultsOptions
+): void => {
+  if (!options?.preserve_name_dev) {
+    node.name_dev = MAP_EDIT_DEFAULT_LIST_NAME_DEV;
+  }
+  node.info = {
+    type: 'list',
+    list_name: MAP_EDIT_DEFAULT_LIST_LEVEL_NAME,
+    list_count_expected: null
+  };
+  node.list = [];
+};
+
+export const create_map_edit_child = (kind: 'shloka' | 'list'): MapNodeWithClientId => {
+  const clientId = new_client_id();
+  const node: MapNodeWithClientId = {
+    name_dev: '',
+    info: { type: 'shloka', shloka_count: 0, total: 0, shloka_count_expected: null },
+    list: [],
+    [MAP_EDIT_CLIENT_ID]: clientId
+  };
+  if (kind === 'shloka') {
+    apply_map_edit_shloka_defaults(node);
+  } else {
+    apply_map_edit_list_defaults(node);
+  }
+  return node;
+};
 
 export const parse_path_query = (raw: string | null): MapPath => {
   if (!raw?.trim()) return [];
@@ -332,7 +395,25 @@ export const compute_map_edit_diff = (
   const walk = (node: MapNodeWithClientId, path: MapPath) => {
     const clientId = node[MAP_EDIT_CLIENT_ID]!;
     const snap = snapshots.get(clientId);
-    if (!snap) return;
+    if (!snap) {
+      const label = format_path_short_label(path);
+      const position = path[path.length - 1] ?? 0;
+      const childKind = node.info.type === 'shloka' ? 'shloka' : 'list';
+      flagsByClientId.set(clientId, { edited: true, moved: false });
+      rows.push({
+        kind: 'add_child',
+        clientId,
+        path,
+        pathLabel: label,
+        summary: `Added ${childKind} child at position ${position}`
+      });
+      if (node.info.type === 'list') {
+        (node.list ?? []).forEach((child, i) => {
+          walk(child as MapNodeWithClientId, [...path, i + 1]);
+        });
+      }
+      return;
+    }
 
     if (path.length > 0) {
       const parentKey = snap.parentClientId;
@@ -346,6 +427,21 @@ export const compute_map_edit_diff = (
     const label = format_path_short_label(path);
     let edited = false;
 
+    const wInfo = node.info;
+    const bInfo = snap.info;
+    if (wInfo.type !== bInfo.type) {
+      edited = true;
+      const from = bInfo.type === 'shloka' ? 'Shloka' : 'List';
+      const to = wInfo.type === 'shloka' ? 'Shloka' : 'List';
+      rows.push({
+        kind: 'type_change',
+        clientId,
+        path,
+        pathLabel: label,
+        summary: `Converted ${from} → ${to}`
+      });
+    }
+
     if (node.name_dev !== snap.name_dev) {
       edited = true;
       rows.push({
@@ -357,8 +453,6 @@ export const compute_map_edit_diff = (
       });
     }
 
-    const wInfo = node.info;
-    const bInfo = snap.info;
     if (wInfo.type === 'list' && bInfo.type === 'list' && path.length > 0) {
       if (wInfo.list_name !== bInfo.list_name) {
         edited = true;

--- a/app/src/server/map_path_swap.test.ts
+++ b/app/src/server/map_path_swap.test.ts
@@ -163,7 +163,10 @@ describe('map_path_swap', () => {
     };
     const merged = applyMetadataEditsToMap(current, proposed);
     expect(merged.list?.[0]?.list?.[0]?.name_dev).toBe('A1 renamed');
-    expect(merged.list?.[0]?.list?.[0]?.info).toEqual(current.list?.[0]?.list?.[0]?.info);
+    expect(merged.list?.[0]?.list?.[0]?.info).toEqual({
+      ...current.list?.[0]?.list?.[0]?.info,
+      shloka_count_expected: 999
+    });
   });
 
   it('rejects metadata saves that reshape the tree', () => {
@@ -187,6 +190,11 @@ describe('map_path_swap', () => {
 
   it('accepts childless shloka to list conversion', () => {
     const current = sampleMap();
+    current.list![1] = {
+      name_dev: 'B',
+      info: { type: 'shloka', shloka_count: 0, total: 0, shloka_count_expected: null },
+      list: []
+    };
     const proposed = sampleMap();
     proposed.list![1] = {
       name_dev: 'B',

--- a/app/src/server/map_path_swap.test.ts
+++ b/app/src/server/map_path_swap.test.ts
@@ -107,12 +107,10 @@ describe('map_path_swap', () => {
   });
 
   it('rejects swap edits outside the chosen root scope', () => {
-    expect(
-      validateSwapEditsRootScope([{ swap_paths: ['1:1:2', '1:1:3'] }], [1, 1])
-    ).toBeNull();
-    expect(
-      validateSwapEditsRootScope([{ swap_paths: ['1:1', '1:1:2'] }], [1, 1])
-    ).toBe('Swap 1: Path A must stay under root /1/1');
+    expect(validateSwapEditsRootScope([{ swap_paths: ['1:1:2', '1:1:3'] }], [1, 1])).toBeNull();
+    expect(validateSwapEditsRootScope([{ swap_paths: ['1:1', '1:1:2'] }], [1, 1])).toBe(
+      'Swap 1: Path A must stay under root /1/1'
+    );
   });
 
   it('expands one drag move into adjacent swaps', () => {

--- a/app/src/server/map_path_swap.test.ts
+++ b/app/src/server/map_path_swap.test.ts
@@ -173,6 +173,103 @@ describe('map_path_swap', () => {
     expect(() => applyMetadataEditsToMap(current, proposed)).toThrow('Map structure changed');
   });
 
+  it('accepts an appended child at the end of a list', () => {
+    const current = sampleMap();
+    const proposed = sampleMap();
+    proposed.list![0]!.list!.push({
+      name_dev: 'A3',
+      info: { type: 'shloka', shloka_count: 0, total: 0, shloka_count_expected: null },
+      list: []
+    });
+    const merged = applyMetadataEditsToMap(current, proposed);
+    expect(merged.list?.[0]?.list?.map((node) => node.name_dev)).toEqual(['A1', 'A2', 'A3']);
+  });
+
+  it('accepts childless shloka to list conversion', () => {
+    const current = sampleMap();
+    const proposed = sampleMap();
+    proposed.list![1] = {
+      name_dev: 'B',
+      info: { type: 'list', list_name: 'Adhyaya', list_count_expected: 5 },
+      list: []
+    };
+    const merged = applyMetadataEditsToMap(current, proposed);
+    expect(merged.list?.[1]?.info).toEqual({
+      type: 'list',
+      list_name: 'Adhyaya',
+      list_count_expected: 5
+    });
+  });
+
+  it('accepts childless type conversion with appended children in the same save', () => {
+    const current: recursive_list_type = {
+      name_dev: 'Project',
+      info: { type: 'shloka', shloka_count: 0, total: 0, shloka_count_expected: null },
+      list: []
+    };
+    const proposed: recursive_list_type = {
+      name_dev: 'Project',
+      info: { type: 'list', list_name: 'Kanda', list_count_expected: null },
+      list: [
+        {
+          name_dev: 'A',
+          info: { type: 'shloka', shloka_count: 0, total: 0, shloka_count_expected: null },
+          list: []
+        }
+      ]
+    };
+    const merged = applyMetadataEditsToMap(current, proposed);
+    expect(merged.info.type).toBe('list');
+    expect(merged.list?.map((n) => n.name_dev)).toEqual(['A']);
+  });
+
+  it('rejects saving a shloka node as the project map root', () => {
+    const current = sampleMap();
+    const proposed: recursive_list_type = {
+      name_dev: 'Project',
+      info: { type: 'shloka', shloka_count: 0, total: 0, shloka_count_expected: null },
+      list: []
+    };
+    expect(() => applyMetadataEditsToMap(current, proposed)).toThrow(
+      'Project map root must be a list node'
+    );
+  });
+
+  it('accepts childless list to shloka conversion', () => {
+    const current = sampleMap();
+    const proposed = sampleMap();
+    proposed.list![1] = {
+      name_dev: 'B',
+      info: { type: 'shloka', shloka_count: 99, total: 99, shloka_count_expected: 99 },
+      list: []
+    };
+    const merged = applyMetadataEditsToMap(current, proposed);
+    expect(merged.list?.[1]?.info).toEqual({
+      type: 'shloka',
+      shloka_count: 0,
+      total: 0,
+      shloka_count_expected: 99
+    });
+  });
+
+  it('rejects type conversion when the node has children', () => {
+    const current = sampleMap();
+    const proposed = sampleMap();
+    proposed.list![0] = {
+      name_dev: 'A',
+      info: { type: 'shloka', shloka_count: 0, total: 0, shloka_count_expected: null },
+      list: []
+    };
+    expect(() => applyMetadataEditsToMap(current, proposed)).toThrow('Map structure changed');
+  });
+
+  it('rejects metadata saves that delete children', () => {
+    const current = sampleMap();
+    const proposed = sampleMap();
+    proposed.list![0]!.list = [proposed.list![0]!.list![0]!];
+    expect(() => applyMetadataEditsToMap(current, proposed)).toThrow('Map structure changed');
+  });
+
   it('rejects swapped same-shaped siblings during metadata-only saves', () => {
     const current: recursive_list_type = {
       name_dev: 'Project',

--- a/app/src/server/map_path_swap.ts
+++ b/app/src/server/map_path_swap.ts
@@ -252,7 +252,11 @@ function mergeMetadataNode(
   if (current.info.type === 'shloka' && proposed.info.type === 'shloka') {
     return {
       name_dev: proposed.name_dev,
-      info: current.info,
+      info: {
+        ...current.info,
+        shloka_count_expected:
+          proposed.info.shloka_count_expected ?? current.info.shloka_count_expected
+      },
       list: []
     };
   }

--- a/app/src/server/map_path_swap.ts
+++ b/app/src/server/map_path_swap.ts
@@ -197,7 +197,10 @@ export function validateSwapEdits(edits: PathSwapEdit[]): string | null {
   return null;
 }
 
-export function validateSwapEditsRootScope(edits: PathSwapEdit[], rootPath: number[]): string | null {
+export function validateSwapEditsRootScope(
+  edits: PathSwapEdit[],
+  rootPath: number[]
+): string | null {
   const rootLabel = formatMapPath(rootPath);
   for (let i = 0; i < edits.length; i++) {
     const [pathA, pathB] = edits[i]!.swap_paths;
@@ -255,7 +258,9 @@ export function applyMetadataEditsToMap(
     // Without stable child ids, ambiguous siblings must keep their local metadata identity in place
     // or we cannot tell whether the client renamed a node or swapped same-shaped siblings.
     const duplicateFingerprints = new Set(
-      currentFingerprints.filter((fingerprint, index) => currentFingerprints.indexOf(fingerprint) !== index)
+      currentFingerprints.filter(
+        (fingerprint, index) => currentFingerprints.indexOf(fingerprint) !== index
+      )
     );
     for (const fingerprint of duplicateFingerprints) {
       const currentLocalIds = currentChildren
@@ -334,15 +339,12 @@ export function applySwapEditsToMap(
     const indexB = dbPathToMapPath(pathB).at(-1)! - 1;
     const parent = parentPath.length === 0 ? next : get_node_at_path(next, parentPath);
     if (!parent || parent.info.type !== 'list') {
-      throw new TypeError(`Cannot apply swap under missing parent "${mapPathToDbPath(parentPath)}"`);
+      throw new TypeError(
+        `Cannot apply swap under missing parent "${mapPathToDbPath(parentPath)}"`
+      );
     }
     const list = [...(parent.list ?? [])];
-    if (
-      indexA < 0 ||
-      indexB < 0 ||
-      indexA >= list.length ||
-      indexB >= list.length
-    ) {
+    if (indexA < 0 || indexB < 0 || indexA >= list.length || indexB >= list.length) {
       throw new RangeError(`Cannot apply swap "${pathA}" <-> "${pathB}" outside list bounds`);
     }
     [list[indexA], list[indexB]] = [list[indexB]!, list[indexA]!];

--- a/app/src/server/map_path_swap.ts
+++ b/app/src/server/map_path_swap.ts
@@ -229,73 +229,251 @@ export function validateOrderRootPath(map: recursive_list_type, rootPath: number
 }
 
 /**
- * Applies only metadata fields that the editor is allowed to change while keeping the tree shape
- * and derived shloka counters intact.
+ * Merges normal-mode map edits: metadata, append-only children, and childless shloka/list conversion.
+ * Rejects reorder, deletion, conversion with children, and client edits to derived shloka counters.
  */
 export function applyMetadataEditsToMap(
   currentMap: recursive_list_type,
   proposedMap: recursive_list_type
 ): recursive_list_type {
-  if (currentMap.info.type !== proposedMap.info.type) {
-    throw new TypeError('Map node type changed during metadata save');
+  if (proposedMap.info.type === 'shloka') {
+    throw new TypeError('Project map root must be a list node');
   }
-  if (currentMap.info.type === 'list') {
-    if (proposedMap.info.type !== 'list') {
-      throw new TypeError('List node changed type during metadata save');
+  return mergeMetadataNode(currentMap, proposedMap);
+}
+
+function mergeMetadataNode(
+  current: recursive_list_type,
+  proposed: recursive_list_type
+): recursive_list_type {
+  if (current.info.type === 'list' && proposed.info.type === 'list') {
+    return mergeMetadataListNode(current, proposed);
+  }
+  if (current.info.type === 'shloka' && proposed.info.type === 'shloka') {
+    return {
+      name_dev: proposed.name_dev,
+      info: current.info,
+      list: []
+    };
+  }
+  if (isChildlessTypeConversion(current, proposed)) {
+    return mergeAfterChildlessTypeConversion(current, proposed);
+  }
+  throw new TypeError('Map node type changed during metadata save');
+}
+
+/** Applies a type swap on a childless server node; proposed may already include new children. */
+function mergeAfterChildlessTypeConversion(
+  current: recursive_list_type,
+  proposed: recursive_list_type
+): recursive_list_type {
+  if (proposed.info.type === 'list') {
+    return mergeMetadataListNode(
+      {
+        name_dev: proposed.name_dev,
+        info: {
+          type: 'list',
+          list_name: proposed.info.list_name,
+          list_count_expected: proposed.info.list_count_expected
+        },
+        list: []
+      },
+      proposed
+    );
+  }
+  return adoptConvertedNode(proposed);
+}
+
+function mergeMetadataListNode(
+  current: recursive_list_type,
+  proposed: recursive_list_type
+): recursive_list_type {
+  if (proposed.info.type !== 'list') {
+    throw new TypeError('List node changed type during metadata save');
+  }
+  const currentChildren = current.list ?? [];
+  const proposedChildren = proposed.list ?? [];
+  if (proposedChildren.length < currentChildren.length) {
+    throw new TypeError('Map structure changed during metadata save');
+  }
+  if (proposedChildren.length > currentChildren.length) {
+    const prefixFingerprints = currentChildren.map(metadataStructureFingerprint);
+    const proposedPrefixFingerprints = proposedChildren
+      .slice(0, currentChildren.length)
+      .map(metadataStructureFingerprint);
+    for (let i = 0; i < prefixFingerprints.length; i++) {
+      const currentChild = currentChildren[i]!;
+      const proposedChild = proposedChildren[i]!;
+      if (prefixFingerprints[i] !== proposedPrefixFingerprints[i]) {
+        if (
+          !isChildlessTypeConversion(currentChild, proposedChild) &&
+          !isAppendOnlySubtreeChange(currentChild, proposedChild)
+        ) {
+          throw new TypeError('Map structure changed during metadata save');
+        }
+      }
     }
-    const currentChildren = currentMap.list ?? [];
-    const proposedChildren = proposedMap.list ?? [];
-    if (currentChildren.length !== proposedChildren.length) {
-      throw new TypeError('Map structure changed during metadata save');
-    }
+  } else {
     const currentFingerprints = currentChildren.map(metadataStructureFingerprint);
     const proposedFingerprints = proposedChildren.map(metadataStructureFingerprint);
     for (let i = 0; i < currentFingerprints.length; i++) {
+      const currentChild = currentChildren[i]!;
+      const proposedChild = proposedChildren[i]!;
       if (currentFingerprints[i] !== proposedFingerprints[i]) {
-        throw new TypeError('Map structure changed during metadata save');
+        if (
+          !isChildlessTypeConversion(currentChild, proposedChild) &&
+          !isAppendOnlySubtreeChange(currentChild, proposedChild)
+        ) {
+          throw new TypeError('Map structure changed during metadata save');
+        }
       }
     }
-    // Without stable child ids, ambiguous siblings must keep their local metadata identity in place
-    // or we cannot tell whether the client renamed a node or swapped same-shaped siblings.
-    const duplicateFingerprints = new Set(
-      currentFingerprints.filter(
-        (fingerprint, index) => currentFingerprints.indexOf(fingerprint) !== index
+    assertNoAmbiguousSiblingReorder(currentChildren, proposedChildren);
+  }
+
+  const mergedChildren: recursive_list_type[] = [];
+  for (let i = 0; i < proposedChildren.length; i++) {
+    if (i < currentChildren.length) {
+      mergedChildren.push(mergeMetadataNode(currentChildren[i]!, proposedChildren[i]!));
+    } else {
+      mergedChildren.push(adoptNewSubtree(proposedChildren[i]!));
+    }
+  }
+
+  return {
+    name_dev: proposed.name_dev,
+    info: {
+      type: 'list',
+      list_name: proposed.info.list_name,
+      list_count_expected: proposed.info.list_count_expected
+    },
+    list: mergedChildren
+  };
+}
+
+function assertNoAmbiguousSiblingReorder(
+  currentChildren: recursive_list_type[],
+  proposedChildren: recursive_list_type[]
+): void {
+  const currentFingerprints = currentChildren.map(metadataStructureFingerprint);
+  const proposedFingerprints = proposedChildren.map(metadataStructureFingerprint);
+  const duplicateFingerprints = new Set(
+    currentFingerprints.filter(
+      (fingerprint, index) => currentFingerprints.indexOf(fingerprint) !== index
+    )
+  );
+  for (const fingerprint of duplicateFingerprints) {
+    const currentLocalIds = currentChildren
+      .map((child, index) =>
+        currentFingerprints[index] === fingerprint ? metadataLocalIdentity(child) : null
       )
-    );
-    for (const fingerprint of duplicateFingerprints) {
-      const currentLocalIds = currentChildren
-        .map((child, index) =>
-          currentFingerprints[index] === fingerprint ? metadataLocalIdentity(child) : null
-        )
-        .filter((value): value is string => value !== null);
-      const proposedLocalIds = proposedChildren
-        .map((child, index) =>
-          proposedFingerprints[index] === fingerprint ? metadataLocalIdentity(child) : null
-        )
-        .filter((value): value is string => value !== null);
+      .filter((value): value is string => value !== null);
+    const proposedLocalIds = proposedChildren
+      .map((child, index) =>
+        proposedFingerprints[index] === fingerprint ? metadataLocalIdentity(child) : null
+      )
+      .filter((value): value is string => value !== null);
+    if (
+      currentLocalIds.join('|') !== proposedLocalIds.join('|') &&
+      [...currentLocalIds].sort().join('|') === [...proposedLocalIds].sort().join('|')
+    ) {
+      throw new TypeError('Ambiguous sibling identity changed during metadata save');
+    }
+  }
+}
+
+function isAppendOnlySubtreeChange(
+  current: recursive_list_type,
+  proposed: recursive_list_type
+): boolean {
+  if (current.info.type !== 'list' || proposed.info.type !== 'list') {
+    return false;
+  }
+  const currentChildren = current.list ?? [];
+  const proposedChildren = proposed.list ?? [];
+  if (proposedChildren.length <= currentChildren.length) {
+    return false;
+  }
+  for (let i = 0; i < currentChildren.length; i++) {
+    const currentChild = currentChildren[i]!;
+    const proposedChild = proposedChildren[i]!;
+    if (
+      metadataStructureFingerprint(currentChild) !== metadataStructureFingerprint(proposedChild)
+    ) {
       if (
-        currentLocalIds.join('|') !== proposedLocalIds.join('|') &&
-        [...currentLocalIds].sort().join('|') === [...proposedLocalIds].sort().join('|')
+        !isChildlessTypeConversion(currentChild, proposedChild) &&
+        !isAppendOnlySubtreeChange(currentChild, proposedChild)
       ) {
-        throw new TypeError('Ambiguous sibling identity changed during metadata save');
+        return false;
       }
     }
+  }
+  return true;
+}
+
+function isChildlessTypeConversion(
+  current: recursive_list_type,
+  proposed: recursive_list_type
+): boolean {
+  if (current.info.type === proposed.info.type) {
+    return false;
+  }
+  if ((current.list ?? []).length > 0) {
+    return false;
+  }
+  return (
+    (current.info.type === 'shloka' && proposed.info.type === 'list') ||
+    (current.info.type === 'list' && proposed.info.type === 'shloka')
+  );
+}
+
+function adoptConvertedNode(proposed: recursive_list_type): recursive_list_type {
+  if (proposed.info.type === 'list') {
     return {
-      name_dev: proposedMap.name_dev,
+      name_dev: proposed.name_dev,
       info: {
         type: 'list',
-        list_name: proposedMap.info.list_name,
-        list_count_expected: proposedMap.info.list_count_expected
+        list_name: proposed.info.list_name,
+        list_count_expected: proposed.info.list_count_expected
       },
-      list: currentChildren.map((child, index) =>
-        applyMetadataEditsToMap(child, proposedChildren[index]!)
-      )
+      list: []
     };
   }
   return {
-    name_dev: proposedMap.name_dev,
-    info: currentMap.info,
+    name_dev: proposed.name_dev,
+    info: {
+      type: 'shloka',
+      shloka_count: 0,
+      total: 0,
+      shloka_count_expected:
+        proposed.info.type === 'shloka' ? proposed.info.shloka_count_expected : null
+    },
     list: []
+  };
+}
+
+function adoptNewSubtree(proposed: recursive_list_type): recursive_list_type {
+  if (proposed.info.type === 'shloka') {
+    return {
+      name_dev: proposed.name_dev,
+      info: {
+        type: 'shloka',
+        shloka_count: 0,
+        total: 0,
+        shloka_count_expected:
+          proposed.info.type === 'shloka' ? proposed.info.shloka_count_expected : null
+      },
+      list: []
+    };
+  }
+  return {
+    name_dev: proposed.name_dev,
+    info: {
+      type: 'list',
+      list_name: proposed.info.list_name,
+      list_count_expected: proposed.info.list_count_expected
+    },
+    list: (proposed.list ?? []).map(adoptNewSubtree)
   };
 }
 

--- a/app/src/server/map_path_swap_db.test.ts
+++ b/app/src/server/map_path_swap_db.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import {
-  applyPathSwapEditsToPath,
-  dbPathMatchesPrefix,
-  remapDbPathPrefix
-} from './map_path_swap';
+import { applyPathSwapEditsToPath, dbPathMatchesPrefix, remapDbPathPrefix } from './map_path_swap';
 import {
   buildRedisKeysForPathSwapInvalidation,
   mergePathSwapInvalidation

--- a/app/src/state/data_types.ts
+++ b/app/src/state/data_types.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 export const recursive_list_schema = z.object({
   name_dev: z.string().describe('Name in Devanagari'),
-  // Every text map starts with a top level where `name_dev` is actually the name of the
+  // Every text map starts with a top level where `name_dev` is actually the name of the project itself
   get list() {
     return recursive_list_schema.array();
   },


### PR DESCRIPTION
- **fomat**
- **added child and and type swap for childless nodes in project map editor**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ability to add child nodes (Shloka or List) to map nodes
  * Added ability to convert between Shloka and List node types for childless nodes
  * Enhanced changes panel to display add child, reorder, and type change operations

* **Tests**
  * Added comprehensive test suite for structure editing scenarios
  * Expanded tests to cover type conversions and child appending

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shubhattin/thesanskritchannel_projects/pull/76?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->