### PR TITLE
feat: Add undo feature in the Project Map Editor

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -49,6 +49,7 @@
     "drizzle-orm": "^0.45.2",
     "drizzle-zod": "^0.8.3",
     "exceljs": "^4.4.0",
+    "immer": "^11.1.8",
     "js-yaml": "^4.1.1",
     "json-2-csv": "^5.5.10",
     "jszip": "^3.10.1",

--- a/app/src/components/pages/map_edit/NodeEditor.svelte
+++ b/app/src/components/pages/map_edit/NodeEditor.svelte
@@ -25,6 +25,7 @@
     onNameDevChange,
     onListNameChange,
     onListCountChange,
+    onInputFieldFocus,
     onAddShlokaChild,
     onAddListChild,
     onConvertToList,
@@ -40,6 +41,7 @@
     onNameDevChange: (value: string) => void;
     onListNameChange: (value: string) => void;
     onListCountChange: (raw: string) => void;
+    onInputFieldFocus: () => void;
     onAddShlokaChild: () => void;
     onAddListChild: () => void;
     onConvertToList: () => void;
@@ -189,6 +191,7 @@
           oninput={(e) => onNameDevChange(e.currentTarget.value)}
           onbeforeinput={(e) =>
             handleTypingBeforeInputEvent(typing_ctx, e, onNameDevChange, typing_enabled)}
+          onfocus={onInputFieldFocus}
           onblur={() => typing_ctx.clearContext()}
           onkeydown={(e) => {
             if (toggle_typing_from_keyboard(e)) return;
@@ -283,6 +286,7 @@
             value={selectedNode.info.list_name}
             disabled={editor_locked}
             oninput={(e) => onListNameChange(e.currentTarget.value)}
+            onfocus={onInputFieldFocus}
           />
           <div
             class="flex gap-2 rounded-lg border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-950 dark:text-amber-100"
@@ -313,6 +317,7 @@
             bind:value={list_count_draft}
             disabled={editor_locked}
             oninput={(e) => onListCountChange(e.currentTarget.value)}
+            onfocus={onInputFieldFocus}
             aria-invalid={count_input_invalid}
           />
           {#if count_input_invalid}

--- a/app/src/components/pages/map_edit/ProjectMapEditor.svelte
+++ b/app/src/components/pages/map_edit/ProjectMapEditor.svelte
@@ -25,10 +25,12 @@
     type MapPath,
     type BaselineNodeSnapshot,
     type MapTreeItem,
-    type MetadataUndoSnapshot,
-    type OrderUndoSnapshot,
-    type DeleteUndoSnapshot,
+    type MetadataUndoEntry,
+    type OrderUndoEntry,
+    type DeleteUndoEntry,
     UndoStack,
+    produceWithPatches,
+    applyPatches,
     clone_map_with_client_ids,
     strip_client_ids,
     is_path_valid,
@@ -95,9 +97,11 @@
   let expandedTreePaths = $state<Set<string>>(default_tree_expanded_paths());
 
   // ── Undo stacks (one per mode) ──
-  let metadata_undo = $state(new UndoStack<MetadataUndoSnapshot>());
-  let order_undo = $state(new UndoStack<OrderUndoSnapshot>());
-  let delete_undo = $state(new UndoStack<DeleteUndoSnapshot>());
+  // Plain variables — mutations are internal to UndoStack; reactivity is
+  // tracked entirely through `undo_version`.
+  let metadata_undo = new UndoStack<MetadataUndoEntry>();
+  let order_undo = new UndoStack<OrderUndoEntry>();
+  let delete_undo = new UndoStack<DeleteUndoEntry>();
   /** Bumped after every push/undo/clear so Svelte re-derives `can_undo`. */
   let undo_version = $state(0);
   const can_undo = $derived.by(() => {
@@ -328,32 +332,68 @@
 
   // ── Undo helpers ──
 
-  function push_metadata_undo() {
-    if (!workingMap) return;
-    metadata_undo.push({
-      workingMap: clone_working_map(workingMap),
-      selectedNodePath: [...selectedNodePath]
-    });
+  /**
+   * Run `recipe` on `workingMap` via immer's `produceWithPatches`.
+   *
+   * - If `groupWithTop` is true AND there's already a top entry on the stack,
+   *   the new inversePatches are PREPENDED to the existing top entry's patches
+   *   (so the whole editing session becomes one undo step).
+   * - Otherwise a new entry is pushed.
+   *
+   * Returns the new map.
+   */
+  function mutate_metadata(
+    recipe: (draft: MapNodeWithClientId) => void,
+    { groupWithTop = false }: { groupWithTop?: boolean } = {}
+  ): MapNodeWithClientId | null {
+    if (!workingMap) return null;
+    const plain = $state.snapshot(workingMap);
+    const [nextMap, , inversePatches] = produceWithPatches(plain, recipe);
+    const top = groupWithTop ? metadata_undo.peek() : null;
+    if (top) {
+      // Merge: prepend new inversePatches so undoing replays them in reverse order
+      top.inversePatches = [...inversePatches, ...top.inversePatches];
+    } else {
+      metadata_undo.push({ inversePatches, selectedNodePath: [...selectedNodePath] });
+    }
     undo_version++;
+    return nextMap as MapNodeWithClientId;
   }
 
-  function push_order_undo() {
-    if (!workingMap) return;
+  /**
+   * Run `recipe` on `workingMap` via immer for an order-mode edit.
+   * Stores inversePatches + current pendingSwaps as the undo entry.
+   */
+  function mutate_order(recipe: (draft: MapNodeWithClientId) => void): MapNodeWithClientId | null {
+    if (!workingMap) return null;
+    const plain = $state.snapshot(workingMap);
+    const [nextMap, , inversePatches] = produceWithPatches(plain, recipe);
     order_undo.push({
-      workingMap: clone_working_map(workingMap),
+      inversePatches,
       pendingSwaps: [...pending_swaps],
       selectedNodePath: [...selectedNodePath]
     });
     undo_version++;
+    return nextMap as MapNodeWithClientId;
   }
 
-  function push_delete_undo() {
-    if (!workingMap) return;
-    delete_undo.push({
-      workingMap: clone_working_map(workingMap),
-      selectedNodePath: [...selectedNodePath]
+  /**
+   * Run `recipe` on `workingMap` via immer for a delete-mode edit.
+   * Returns null if the recipe didn't actually change anything (remove failed).
+   */
+  function mutate_delete(
+    recipe: (draft: MapNodeWithClientId) => boolean
+  ): MapNodeWithClientId | null {
+    if (!workingMap) return null;
+    let changed = false;
+    const plain = $state.snapshot(workingMap);
+    const [nextMap, , inversePatches] = produceWithPatches(plain, (draft) => {
+      changed = recipe(draft);
     });
+    if (!changed) return null;
+    delete_undo.push({ inversePatches, selectedNodePath: [...selectedNodePath] });
     undo_version++;
+    return nextMap as MapNodeWithClientId;
   }
 
   function clear_all_undo_stacks() {
@@ -364,23 +404,24 @@
   }
 
   function undo_action() {
-    if (save_in_flight) return;
+    if (save_in_flight || !workingMap) return;
+    const plain = $state.snapshot(workingMap);
     if (editor_mode === 'order') {
-      const snap = order_undo.undo();
-      if (!snap) return;
-      workingMap = snap.workingMap;
-      pending_swaps = snap.pendingSwaps;
-      selectedNodePath = snap.selectedNodePath;
+      const entry = order_undo.undo();
+      if (!entry) return;
+      workingMap = applyPatches(plain, entry.inversePatches) as MapNodeWithClientId;
+      pending_swaps = entry.pendingSwaps;
+      selectedNodePath = entry.selectedNodePath;
     } else if (editor_mode === 'delete') {
-      const snap = delete_undo.undo();
-      if (!snap) return;
-      workingMap = snap.workingMap;
-      selectedNodePath = snap.selectedNodePath;
+      const entry = delete_undo.undo();
+      if (!entry) return;
+      workingMap = applyPatches(plain, entry.inversePatches) as MapNodeWithClientId;
+      selectedNodePath = entry.selectedNodePath;
     } else {
-      const snap = metadata_undo.undo();
-      if (!snap) return;
-      workingMap = snap.workingMap;
-      selectedNodePath = snap.selectedNodePath;
+      const entry = metadata_undo.undo();
+      if (!entry) return;
+      workingMap = applyPatches(plain, entry.inversePatches) as MapNodeWithClientId;
+      selectedNodePath = entry.selectedNodePath;
     }
     undo_version++;
   }
@@ -478,15 +519,31 @@
   function update_name_dev(value: string) {
     if (!selectedNode || selected_is_root || save_in_flight) return;
     mark_local_change();
-    selectedNode.name_dev = value;
-    bump_working();
+    const fresh = _input_field_fresh_focus;
+    _input_field_fresh_focus = false;
+    const next = mutate_metadata(
+      (draft) => {
+        const node = get_node_at_map_path(draft, selectedNodePath);
+        if (node) node.name_dev = value;
+      },
+      { groupWithTop: !fresh }
+    );
+    if (next) workingMap = next;
   }
 
   function update_list_name(value: string) {
     if (!selectedNode || selectedNode.info.type !== 'list' || save_in_flight) return;
     mark_local_change();
-    selectedNode.info = { ...selectedNode.info, list_name: value };
-    bump_working();
+    const fresh = _input_field_fresh_focus;
+    _input_field_fresh_focus = false;
+    const next = mutate_metadata(
+      (draft) => {
+        const node = get_node_at_map_path(draft, selectedNodePath);
+        if (node && node.info.type === 'list') node.info.list_name = value;
+      },
+      { groupWithTop: !fresh }
+    );
+    if (next) workingMap = next;
   }
 
   function update_list_count_expected(raw: string) {
@@ -498,19 +555,37 @@
     }
     mark_local_change();
     count_input_invalid = false;
-    selectedNode.info = { ...selectedNode.info, list_count_expected: parsed };
-    bump_working();
+    const fresh = _input_field_fresh_focus;
+    _input_field_fresh_focus = false;
+    const next = mutate_metadata(
+      (draft) => {
+        const node = get_node_at_map_path(draft, selectedNodePath);
+        if (node && node.info.type === 'list') node.info.list_count_expected = parsed;
+      },
+      { groupWithTop: !fresh }
+    );
+    if (next) workingMap = next;
   }
 
   /**
    * Called when any input field gains focus.
-   * Captures exactly one undo snapshot per focus session so that
-   * the entire editing session in the field is a single undo step.
+   * Sets a flag so the NEXT keystroke pushes a fresh entry.
+   * Subsequent keystrokes in the same session are merged into that entry
+   * (groupWithTop=true), so the whole typing session is one undo step.
+   * Skips if nothing has changed since the last push (repeated focus with no edit).
    */
   function on_input_field_focus() {
     if (!workingMap || save_in_flight || editor_mode !== 'metadata') return;
-    push_metadata_undo();
+    // No new edits since last snapshot — don't start a new group.
+    if (metadata_undo.canUndo && !diffState.dirty) return;
+    _input_field_fresh_focus = true;
   }
+
+  /**
+   * True after a focus event, until the first keystroke of that session.
+   * The first keystroke pushes a new undo entry; subsequent ones merge into it.
+   */
+  let _input_field_fresh_focus = false;
 
   function on_delete_node_click(e: MouseEvent, subtreePath: string) {
     e.stopPropagation();
@@ -522,8 +597,9 @@
     if (!workingMap || !delete_edit_mode || save_in_flight) return;
     const full = full_path_from_subtree_path(basePath, subtreePath);
     if (full.length === 0) return;
-    push_delete_undo();
-    if (!remove_node_at_path(workingMap, full)) return;
+    const next = mutate_delete((draft) => remove_node_at_path(draft, full));
+    if (!next) return;
+    workingMap = next;
     const parentPath = full.slice(0, -1);
     const removedIndex = full[full.length - 1]!;
     if (paths_equal(selectedNodePath, full) || is_ancestor_path(full, selectedNodePath)) {
@@ -547,7 +623,6 @@
             ? [...basePath]
             : [];
     }
-    bump_working();
   }
 
   function append_child(kind: 'shloka' | 'list') {
@@ -559,10 +634,14 @@
     ) {
       return;
     }
-    push_metadata_undo();
     mark_local_change();
-    selectedNode.list = [...(selectedNode.list ?? []), create_map_edit_child(kind)];
-    bump_working();
+    const next = mutate_metadata((draft) => {
+      const node = get_node_at_map_path(draft, selectedNodePath);
+      if (node && node.info.type === 'list') {
+        node.list = [...(node.list ?? []), create_map_edit_child(kind)];
+      }
+    });
+    if (next) workingMap = next;
   }
 
   function convert_selected_to_list() {
@@ -575,10 +654,12 @@
     ) {
       return;
     }
-    push_metadata_undo();
     mark_local_change();
-    apply_map_edit_list_defaults(selectedNode, { preserve_name_dev: selected_is_root });
-    bump_working();
+    const next = mutate_metadata((draft) => {
+      const node = get_node_at_map_path(draft, selectedNodePath);
+      if (node) apply_map_edit_list_defaults(node, { preserve_name_dev: selected_is_root });
+    });
+    if (next) workingMap = next;
   }
 
   function convert_selected_to_shloka() {
@@ -592,10 +673,12 @@
     ) {
       return;
     }
-    push_metadata_undo();
     mark_local_change();
-    apply_map_edit_shloka_defaults(selectedNode, { preserve_name_dev: selected_is_root });
-    bump_working();
+    const next = mutate_metadata((draft) => {
+      const node = get_node_at_map_path(draft, selectedNodePath);
+      if (node) apply_map_edit_shloka_defaults(node, { preserve_name_dev: selected_is_root });
+    });
+    if (next) workingMap = next;
   }
 
   async function before_drop(
@@ -632,18 +715,16 @@
     if (position === 'below') toIndex += 1;
     if (draggedCtx.index < toIndex) toIndex -= 1;
 
-    push_order_undo();
-    const ok = reorder_siblings(workingMap, draggedCtx.parentPath, draggedCtx.index, toIndex);
-    if (ok) {
+    if (draggedCtx.index === toIndex) return false;
+
+    const fromIndex = draggedCtx.index;
+    const next = mutate_order((draft) => {
+      reorder_siblings(draft, draggedCtx.parentPath, fromIndex, toIndex);
+    });
+    if (next) {
+      workingMap = next;
       mark_local_change();
-      if (draggedCtx.index !== toIndex) {
-        record_pending_swap(draggedCtx.parentPath, draggedCtx.index, toIndex);
-      }
-      bump_working();
-    } else {
-      // Reorder didn't happen (e.g. same index), pop the snapshot we just pushed
-      order_undo.undo();
-      undo_version++;
+      record_pending_swap(draggedCtx.parentPath, fromIndex, toIndex);
     }
     return false;
   }

--- a/app/src/components/pages/map_edit/ProjectMapEditor.svelte
+++ b/app/src/components/pages/map_edit/ProjectMapEditor.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Map as MapIcon, ArrowUpDown, FolderRoot, Trash2 } from '@lucide/svelte';
+  import { Map as MapIcon, ArrowUpDown, FolderRoot, Trash2, Undo2 } from '@lucide/svelte';
   import type { Tree as TreeComponent, LTreeNode, DropPosition } from '@keenmate/svelte-treeview';
   import { browser } from '$app/environment';
   import { beforeNavigate } from '$app/navigation';
@@ -25,6 +25,10 @@
     type MapPath,
     type BaselineNodeSnapshot,
     type MapTreeItem,
+    type MetadataUndoSnapshot,
+    type OrderUndoSnapshot,
+    type DeleteUndoSnapshot,
+    UndoStack,
     clone_map_with_client_ids,
     strip_client_ids,
     is_path_valid,
@@ -89,6 +93,25 @@
   let saving_order = $state(false);
   let last_tree_click = $state<{ path: string; at: number } | null>(null);
   let expandedTreePaths = $state<Set<string>>(default_tree_expanded_paths());
+
+  // ── Undo stacks (one per mode) ──
+  let metadata_undo = $state(new UndoStack<MetadataUndoSnapshot>());
+  let order_undo = $state(new UndoStack<OrderUndoSnapshot>());
+  let delete_undo = $state(new UndoStack<DeleteUndoSnapshot>());
+  /** Bumped after every push/undo/clear so Svelte re-derives `can_undo`. */
+  let undo_version = $state(0);
+  const can_undo = $derived.by(() => {
+    undo_version; // reactive dependency
+    if (editor_mode === 'order') return order_undo.canUndo;
+    if (editor_mode === 'delete') return delete_undo.canUndo;
+    return metadata_undo.canUndo;
+  });
+  const undo_stack_size = $derived.by(() => {
+    undo_version;
+    if (editor_mode === 'order') return order_undo.size;
+    if (editor_mode === 'delete') return delete_undo.size;
+    return metadata_undo.size;
+  });
 
   const TREE_DBLCLICK_MS = 400;
 
@@ -224,6 +247,7 @@
     order_entry_map = null;
     delete_entry_map = null;
     pending_swaps = [];
+    clear_all_undo_stacks();
     await invalidate_project_registry_queries(project_id);
     await invalidate_project_map_queries(project_id);
     if (options.invalidateContent) {
@@ -300,6 +324,65 @@
 
   function mark_local_change() {
     leave_confirmed = false;
+  }
+
+  // ── Undo helpers ──
+
+  function push_metadata_undo() {
+    if (!workingMap) return;
+    metadata_undo.push({
+      workingMap: clone_working_map(workingMap),
+      selectedNodePath: [...selectedNodePath]
+    });
+    undo_version++;
+  }
+
+  function push_order_undo() {
+    if (!workingMap) return;
+    order_undo.push({
+      workingMap: clone_working_map(workingMap),
+      pendingSwaps: [...pending_swaps],
+      selectedNodePath: [...selectedNodePath]
+    });
+    undo_version++;
+  }
+
+  function push_delete_undo() {
+    if (!workingMap) return;
+    delete_undo.push({
+      workingMap: clone_working_map(workingMap),
+      selectedNodePath: [...selectedNodePath]
+    });
+    undo_version++;
+  }
+
+  function clear_all_undo_stacks() {
+    metadata_undo.clear();
+    order_undo.clear();
+    delete_undo.clear();
+    undo_version++;
+  }
+
+  function undo_action() {
+    if (save_in_flight) return;
+    if (editor_mode === 'order') {
+      const snap = order_undo.undo();
+      if (!snap) return;
+      workingMap = snap.workingMap;
+      pending_swaps = snap.pendingSwaps;
+      selectedNodePath = snap.selectedNodePath;
+    } else if (editor_mode === 'delete') {
+      const snap = delete_undo.undo();
+      if (!snap) return;
+      workingMap = snap.workingMap;
+      selectedNodePath = snap.selectedNodePath;
+    } else {
+      const snap = metadata_undo.undo();
+      if (!snap) return;
+      workingMap = snap.workingMap;
+      selectedNodePath = snap.selectedNodePath;
+    }
+    undo_version++;
   }
 
   function select_node_by_subtree_path(subtreePath: string) {
@@ -419,6 +502,16 @@
     bump_working();
   }
 
+  /**
+   * Called when any input field gains focus.
+   * Captures exactly one undo snapshot per focus session so that
+   * the entire editing session in the field is a single undo step.
+   */
+  function on_input_field_focus() {
+    if (!workingMap || save_in_flight || editor_mode !== 'metadata') return;
+    push_metadata_undo();
+  }
+
   function on_delete_node_click(e: MouseEvent, subtreePath: string) {
     e.stopPropagation();
     e.preventDefault();
@@ -429,6 +522,7 @@
     if (!workingMap || !delete_edit_mode || save_in_flight) return;
     const full = full_path_from_subtree_path(basePath, subtreePath);
     if (full.length === 0) return;
+    push_delete_undo();
     if (!remove_node_at_path(workingMap, full)) return;
     const parentPath = full.slice(0, -1);
     const removedIndex = full[full.length - 1]!;
@@ -465,6 +559,7 @@
     ) {
       return;
     }
+    push_metadata_undo();
     mark_local_change();
     selectedNode.list = [...(selectedNode.list ?? []), create_map_edit_child(kind)];
     bump_working();
@@ -480,6 +575,7 @@
     ) {
       return;
     }
+    push_metadata_undo();
     mark_local_change();
     apply_map_edit_list_defaults(selectedNode, { preserve_name_dev: selected_is_root });
     bump_working();
@@ -496,6 +592,7 @@
     ) {
       return;
     }
+    push_metadata_undo();
     mark_local_change();
     apply_map_edit_shloka_defaults(selectedNode, { preserve_name_dev: selected_is_root });
     bump_working();
@@ -535,6 +632,7 @@
     if (position === 'below') toIndex += 1;
     if (draggedCtx.index < toIndex) toIndex -= 1;
 
+    push_order_undo();
     const ok = reorder_siblings(workingMap, draggedCtx.parentPath, draggedCtx.index, toIndex);
     if (ok) {
       mark_local_change();
@@ -542,6 +640,10 @@
         record_pending_swap(draggedCtx.parentPath, draggedCtx.index, toIndex);
       }
       bump_working();
+    } else {
+      // Reorder didn't happen (e.g. same index), pop the snapshot we just pushed
+      order_undo.undo();
+      undo_version++;
     }
     return false;
   }
@@ -557,6 +659,7 @@
       toast.error('Save or discard map edits before changing order');
       return;
     }
+    clear_all_undo_stacks();
     order_entry_map = clone_working_map(workingMap);
     order_entry_snapshots = clone_baseline_snapshots(baselineSnapshots);
     pending_swaps = [];
@@ -573,6 +676,7 @@
       toast.error('Save or discard map edits before deleting nodes');
       return;
     }
+    clear_all_undo_stacks();
     delete_entry_map = clone_working_map(workingMap);
     basePath = [];
     selectedNodePath = [];
@@ -583,6 +687,7 @@
   function cancel_order_edit() {
     if (!order_edit_mode || save_in_flight) return;
     if (!order_dirty) {
+      clear_all_undo_stacks();
       editor_mode = 'metadata';
       order_root_path = null;
       order_entry_map = null;
@@ -598,6 +703,7 @@
   function cancel_delete_edit() {
     if (!delete_edit_mode || save_in_flight) return;
     if (!delete_dirty) {
+      clear_all_undo_stacks();
       editor_mode = 'metadata';
       delete_entry_map = null;
       basePath = [];
@@ -614,6 +720,7 @@
       baselineSnapshots = clone_baseline_snapshots(order_entry_snapshots);
     }
     pending_swaps = [];
+    clear_all_undo_stacks();
     editor_mode = 'metadata';
     order_root_path = null;
     order_entry_map = null;
@@ -628,6 +735,7 @@
     if (delete_entry_map) {
       workingMap = clone_working_map(delete_entry_map);
     }
+    clear_all_undo_stacks();
     editor_mode = 'metadata';
     delete_entry_map = null;
     basePath = [];
@@ -727,6 +835,7 @@
   function restore_from_baseline() {
     if (!baselineMap) return;
     reset_from_server(baselineMap);
+    clear_all_undo_stacks();
     count_input_invalid = false;
     map_edit_dirty.set(false);
   }
@@ -744,8 +853,18 @@
         e.returnValue = '';
       }
     };
+    const on_keydown = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key === 'z' && !e.shiftKey) {
+        e.preventDefault();
+        undo_action();
+      }
+    };
     window.addEventListener('beforeunload', on_beforeunload);
-    return () => window.removeEventListener('beforeunload', on_beforeunload);
+    window.addEventListener('keydown', on_keydown);
+    return () => {
+      window.removeEventListener('beforeunload', on_beforeunload);
+      window.removeEventListener('keydown', on_keydown);
+    };
   });
 
   onDestroy(() => {
@@ -815,6 +934,16 @@
             </Badge>
           {/if}
           {#if delete_edit_mode}
+            <Button
+              variant="outline"
+              size="sm"
+              onclick={undo_action}
+              disabled={!can_undo || save_in_flight}
+              title="Undo (Ctrl+Z)"
+            >
+              <Undo2 class="mr-1 size-3.5" />
+              Undo{undo_stack_size > 0 ? ` (${undo_stack_size})` : ''}
+            </Button>
             <Button variant="outline" size="sm" onclick={cancel_delete_edit}
               >Cancel delete mode</Button
             >
@@ -827,6 +956,16 @@
               {save_in_flight ? 'Saving…' : 'Save deletions'}
             </Button>
           {:else if order_edit_mode}
+            <Button
+              variant="outline"
+              size="sm"
+              onclick={undo_action}
+              disabled={!can_undo || save_in_flight}
+              title="Undo (Ctrl+Z)"
+            >
+              <Undo2 class="mr-1 size-3.5" />
+              Undo{undo_stack_size > 0 ? ` (${undo_stack_size})` : ''}
+            </Button>
             <Button variant="outline" size="sm" onclick={cancel_order_edit}
               >Cancel order edit</Button
             >
@@ -841,6 +980,16 @@
               {save_in_flight ? 'Saving…' : 'Save current order'}
             </Button>
           {:else}
+            <Button
+              variant="outline"
+              size="sm"
+              onclick={undo_action}
+              disabled={!can_undo || save_in_flight}
+              title="Undo (Ctrl+Z)"
+            >
+              <Undo2 class="mr-1 size-3.5" />
+              Undo{undo_stack_size > 0 ? ` (${undo_stack_size})` : ''}
+            </Button>
             <Button variant="outline" size="sm" onclick={request_cancel}>Cancel</Button>
             <Button
               size="sm"
@@ -973,6 +1122,7 @@
       onNameDevChange={update_name_dev}
       onListNameChange={update_list_name}
       onListCountChange={update_list_count_expected}
+      onInputFieldFocus={on_input_field_focus}
       onAddShlokaChild={() => append_child('shloka')}
       onAddListChild={() => append_child('list')}
       onConvertToList={convert_selected_to_list}

--- a/app/src/components/pages/map_edit/map_edit_lib.test.ts
+++ b/app/src/components/pages/map_edit/map_edit_lib.test.ts
@@ -10,6 +10,8 @@ import {
   expand_terminal_deleted_paths,
   get_node_at_map_path,
   remove_node_at_path,
+  UndoStack,
+  UNDO_MAX_DEPTH,
   type BaselineNodeSnapshot,
   type MapNodeWithClientId
 } from './map_edit_lib';
@@ -161,5 +163,94 @@ describe('map_edit_lib delete mode', () => {
     const terminals = expand_terminal_deleted_paths(entry, [[1]]);
     expect(terminals).toContainEqual([1, 1]);
     expect(terminals).toContainEqual([1, 2]);
+  });
+});
+
+describe('UndoStack', () => {
+  it('starts empty with canUndo=false', () => {
+    const stack = new UndoStack<number>();
+    expect(stack.canUndo).toBe(false);
+    expect(stack.size).toBe(0);
+    expect(stack.undo()).toBeNull();
+  });
+
+  it('push and undo return items in LIFO order', () => {
+    const stack = new UndoStack<string>();
+    stack.push('a');
+    stack.push('b');
+    stack.push('c');
+    expect(stack.size).toBe(3);
+    expect(stack.canUndo).toBe(true);
+    expect(stack.undo()).toBe('c');
+    expect(stack.undo()).toBe('b');
+    expect(stack.undo()).toBe('a');
+    expect(stack.undo()).toBeNull();
+    expect(stack.canUndo).toBe(false);
+  });
+
+  it('clear empties the stack', () => {
+    const stack = new UndoStack<number>();
+    stack.push(1);
+    stack.push(2);
+    expect(stack.size).toBe(2);
+    stack.clear();
+    expect(stack.size).toBe(0);
+    expect(stack.canUndo).toBe(false);
+    expect(stack.undo()).toBeNull();
+  });
+
+  it('respects max depth and evicts oldest entries', () => {
+    const stack = new UndoStack<number>(3);
+    stack.push(1);
+    stack.push(2);
+    stack.push(3);
+    stack.push(4); // evicts 1
+    expect(stack.size).toBe(3);
+    expect(stack.undo()).toBe(4);
+    expect(stack.undo()).toBe(3);
+    expect(stack.undo()).toBe(2);
+    expect(stack.undo()).toBeNull();
+  });
+
+  it('works with snapshot-like objects', () => {
+    type Snap = { workingMap: MapNodeWithClientId; selectedNodePath: number[] };
+    const stack = new UndoStack<Snap>();
+    const { working } = setup_working();
+    const snap: Snap = {
+      workingMap: clone_working_map(working),
+      selectedNodePath: [1]
+    };
+    stack.push(snap);
+    const restored = stack.undo();
+    expect(restored).not.toBeNull();
+    expect(restored!.selectedNodePath).toEqual([1]);
+    expect(restored!.workingMap.name_dev).toBe('Project');
+  });
+
+  it('interleaved push and undo work correctly', () => {
+    const stack = new UndoStack<number>();
+    stack.push(10);
+    stack.push(20);
+    expect(stack.undo()).toBe(20);
+    stack.push(30);
+    expect(stack.size).toBe(2);
+    expect(stack.undo()).toBe(30);
+    expect(stack.undo()).toBe(10);
+    expect(stack.undo()).toBeNull();
+  });
+
+  it('uses default max depth of UNDO_MAX_DEPTH', () => {
+    const stack = new UndoStack<number>();
+    for (let i = 0; i < 55; i++) {
+      stack.push(i);
+    }
+    expect(stack.size).toBe(UNDO_MAX_DEPTH);
+    // The first few entries should have been evicted
+    const all: number[] = [];
+    let v: number | null;
+    while ((v = stack.undo()) !== null) all.push(v);
+    // Should have entries 5..54 (i.e., the last 50)
+    expect(all[0]).toBe(54);
+    expect(all[all.length - 1]).toBe(5);
   });
 });

--- a/app/src/components/pages/map_edit/map_edit_lib.ts
+++ b/app/src/components/pages/map_edit/map_edit_lib.ts
@@ -786,24 +786,35 @@ export const build_delete_review_state = (
 };
 
 // ---------------------------------------------------------------------------
-// Undo stack
+// Undo stack — immer patch-based (stores inversePatches, not full clones)
 // ---------------------------------------------------------------------------
+
+import { enablePatches, produceWithPatches, applyPatches, setAutoFreeze, type Patch } from 'immer';
+
+// Must be called once to activate patch tracking in immer.
+enablePatches();
+setAutoFreeze(false);
+
+export { produceWithPatches, applyPatches, type Patch };
 
 export const UNDO_MAX_DEPTH = 50;
 
-export type MetadataUndoSnapshot = {
-  workingMap: MapNodeWithClientId;
+/** Inverse patches that reverse one metadata edit, plus the selection to restore. */
+export type MetadataUndoEntry = {
+  inversePatches: Patch[];
   selectedNodePath: MapPath;
 };
 
-export type OrderUndoSnapshot = {
-  workingMap: MapNodeWithClientId;
+/** Inverse patches that reverse one order edit, plus swaps and selection to restore. */
+export type OrderUndoEntry = {
+  inversePatches: Patch[];
   pendingSwaps: import('~/server/map_path_swap').PathSwapEdit[];
   selectedNodePath: MapPath;
 };
 
-export type DeleteUndoSnapshot = {
-  workingMap: MapNodeWithClientId;
+/** Inverse patches that reverse one delete operation, plus selection to restore. */
+export type DeleteUndoEntry = {
+  inversePatches: Patch[];
   selectedNodePath: MapPath;
 };
 
@@ -819,17 +830,22 @@ export class UndoStack<T> {
     this._maxDepth = maxDepth;
   }
 
-  /** Push a snapshot (captured *before* the mutation). */
-  push(snapshot: T): void {
-    this._stack.push(snapshot);
+  /** Push an entry onto the stack. */
+  push(entry: T): void {
+    this._stack.push(entry);
     if (this._stack.length > this._maxDepth) {
       this._stack.splice(0, this._stack.length - this._maxDepth);
     }
   }
 
-  /** Pop and return the most recent snapshot, or `null` if empty. */
+  /** Pop and return the most recent entry, or `null` if empty. */
   undo(): T | null {
     return this._stack.pop() ?? null;
+  }
+
+  /** Peek at the most recent entry without removing it. */
+  peek(): T | null {
+    return this._stack[this._stack.length - 1] ?? null;
   }
 
   clear(): void {

--- a/app/src/components/pages/map_edit/map_edit_lib.ts
+++ b/app/src/components/pages/map_edit/map_edit_lib.ts
@@ -784,3 +784,63 @@ export const build_delete_review_state = (
   });
   return { deletedRoots, terminalPaths, rows };
 };
+
+// ---------------------------------------------------------------------------
+// Undo stack
+// ---------------------------------------------------------------------------
+
+export const UNDO_MAX_DEPTH = 50;
+
+export type MetadataUndoSnapshot = {
+  workingMap: MapNodeWithClientId;
+  selectedNodePath: MapPath;
+};
+
+export type OrderUndoSnapshot = {
+  workingMap: MapNodeWithClientId;
+  pendingSwaps: import('~/server/map_path_swap').PathSwapEdit[];
+  selectedNodePath: MapPath;
+};
+
+export type DeleteUndoSnapshot = {
+  workingMap: MapNodeWithClientId;
+  selectedNodePath: MapPath;
+};
+
+/**
+ * Generic undo stack with a configurable max depth.
+ * Framework-agnostic — the Svelte component wraps this in reactive state.
+ */
+export class UndoStack<T> {
+  private _stack: T[] = [];
+  private _maxDepth: number;
+
+  constructor(maxDepth: number = UNDO_MAX_DEPTH) {
+    this._maxDepth = maxDepth;
+  }
+
+  /** Push a snapshot (captured *before* the mutation). */
+  push(snapshot: T): void {
+    this._stack.push(snapshot);
+    if (this._stack.length > this._maxDepth) {
+      this._stack.splice(0, this._stack.length - this._maxDepth);
+    }
+  }
+
+  /** Pop and return the most recent snapshot, or `null` if empty. */
+  undo(): T | null {
+    return this._stack.pop() ?? null;
+  }
+
+  clear(): void {
+    this._stack = [];
+  }
+
+  get canUndo(): boolean {
+    return this._stack.length > 0;
+  }
+
+  get size(): number {
+    return this._stack.length;
+  }
+}

--- a/bun.lock
+++ b/bun.lock
@@ -35,6 +35,7 @@
         "drizzle-orm": "^0.45.2",
         "drizzle-zod": "^0.8.3",
         "exceljs": "^4.4.0",
+        "immer": "^11.1.8",
         "js-yaml": "^4.1.1",
         "json-2-csv": "^5.5.10",
         "jszip": "^3.10.1",
@@ -1496,6 +1497,8 @@
     "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
 
     "immediate": ["immediate@3.0.6", "", {}, "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="],
+
+    "immer": ["immer@11.1.8", "", {}, "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA=="],
 
     "immutable": ["immutable@5.1.5", "", {}, "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A=="],
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Map editor now supports undo functionality via Ctrl+Z keyboard shortcut
  * Added Undo button in each editor mode displaying undo availability
  * Consecutive metadata field edits are automatically grouped together in undo history for improved workflow efficiency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->